### PR TITLE
fix single line jsonl parse error 

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -1,0 +1,33 @@
+name: Ruby Gem
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "master"
+    tags:
+      - "*"
+  pull_request:
+    branches:
+      - "master"
+    types: [opened, synchronize]
+
+jobs:
+  build:
+    name: Build + Publish
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: push gem
+        uses: trocco-io/push-gem-to-gpr-action@v1
+        with:
+          language: java
+          gem-path: "./pkg/*.gem"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "com.jfrog.bintray" version "1.1"
     id "com.github.jruby-gradle.base" version "0.1.5"
+    id "com.palantir.git-version" version "0.13.0"
     id "java"
     id "jacoco"
 }
@@ -13,7 +14,14 @@ configurations {
     provided
 }
 
-version = "0.2.2"
+version = {
+    def vd = versionDetails()
+    if (vd.commitDistance == 0 && vd.lastTag ==~ /^[0-9]+\.[0-9]+\.[0-9]+(\.[a-zA-Z0-9]+)?/) {
+        vd.lastTag
+    } else {
+        "0.0.0.${vd.gitHash}.pre"
+    }
+}()
 
 compileJava.options.encoding = 'UTF-8' // source encoding
 sourceCompatibility = 1.7

--- a/lib/embulk/guess/jsonl.rb
+++ b/lib/embulk/guess/jsonl.rb
@@ -5,16 +5,18 @@ module Embulk
   module Guess
     # $ embulk guess -g "jsonl" partial-config.yml
 
-    class Jsonl < LineGuessPlugin # TODO should use GuessPlugin instead of LineGuessPlugin
+    class Jsonl < TextGuessPlugin
       Plugin.register_guess("jsonl", self)
 
-      def guess_lines(config, sample_lines)
-        #return {} unless config.fetch("parser", {}).fetch("type", "jsonl") == "jsonl"
+      def guess_text(config, sample_text)
+        return {} unless config.dig("parser", "type") == "jsonl"
 
         rows = []
 
-        columns = {}
-        sample_lines.each do |line|
+        newline_type = config.fetch("parser", {}).fetch("newline", "LF")
+        newline_char = newline_character(newline_type)
+        sample_text.split(newline_char).each do |line|
+          next if line.strip.empty?
           rows << JSON.parse(line)
         end
 
@@ -35,6 +37,21 @@ module Embulk
         parser_guessed = {"type" => "jsonl"}
         parser_guessed["columns"] = columns
         return {"parser" => parser_guessed}
+      end
+
+      private
+
+      def newline_character(newline_type)
+        case newline_type
+        when "LF"
+          "\n"
+        when "CR"
+          "\r"
+        when "CRLF"
+          "\r\n"
+        else
+          "\n"
+        end
       end
     end
   end

--- a/lib/embulk/guess/jsonl.rb
+++ b/lib/embulk/guess/jsonl.rb
@@ -13,7 +13,7 @@ module Embulk
 
         rows = []
 
-        newline_type = config.fetch("parser", {}).fetch("newline", "LF")
+        newline_type = config.fetch("parser", {}).fetch("newline", "CRLF")
         newline_char = newline_character(newline_type)
         sample_text.split(newline_char).each do |line|
           next if line.strip.empty?
@@ -43,14 +43,14 @@ module Embulk
 
       def newline_character(newline_type)
         case newline_type
+        when "CRLF"
+          "\r\n"
         when "LF"
           "\n"
         when "CR"
           "\r"
-        when "CRLF"
-          "\r\n"
         else
-          "\n"
+          "\r\n"
         end
       end
     end


### PR DESCRIPTION
# この PR はなぜ必要なのか (Why)
改行なし単行 JSONL のデータ自動データ設定が失敗するので

# この PR は何をやっているのか (What)
- そもそもの原因はembulk coreのこの部分 https://github.com/embulk/embulk/blob/d5b47261203f5d5622a689c726a8ca6e9f208349/embulk-core/src/main/ruby/embulk/guess_plugin.rb#L116-L118
JsonlParserはLineGuessPluginを継承していて，LineGuessParserは最終行の末尾に改行がないと不正な行とみなしている

- https://github.com/primenumber-dev/n-transfer-ui/issues/7394#issue-1024909796 記載の選択肢で、jsonpath のように、[TextGuessPlugin](https://github.com/embulk/embulk/blob/d5b47261203f5d5622a689c726a8ca6e9f208349/embulk-core/src/main/ruby/embulk/guess_plugin.rb#L46) を継承する形で単行の場合に要素の除外が行われないように対応を行った。その上で指定の改行コードで行ごとに処理が出来るように対応した

# Issue / Reference
- ref: https://github.com/primenumber-dev/n-transfer-ui/issues/7117
- ref: https://github.com/primenumber-dev/n-transfer-ui/issues/7394
- ref: https://github.com/primenumber-dev/n-transfer-ui/pull/18437 で組み込みの挙動確認