### PR TITLE
改行や空白だけの行の時にエラーになる問題を修正

### DIFF
--- a/src/main/java/org/embulk/parser/jsonl/JsonlParserPlugin.java
+++ b/src/main/java/org/embulk/parser/jsonl/JsonlParserPlugin.java
@@ -175,6 +175,11 @@ public class JsonlParserPlugin implements ParserPlugin {
           }
           lineNumber++;
 
+          // Skip empty lines
+          if (line.trim().isEmpty()) {
+            continue;
+          }
+
           try {
             Value value = jsonParser.parse(line);
 

--- a/src/test/java/org/embulk/parser/jsonl/TestJsonlParserPlugin.java
+++ b/src/test/java/org/embulk/parser/jsonl/TestJsonlParserPlugin.java
@@ -241,6 +241,129 @@ public class TestJsonlParserPlugin {
     }
   }
 
+  @Test
+  public void testTrailingEmptyLine() throws Exception {
+    SchemaConfig schema =
+        schema(column("_c0", BOOLEAN), column("_c1", LONG), column("_c2", STRING));
+    ConfigSource config = config().set("columns", schema);
+
+    // Simulates a file with a trailing newline: the last element "" represents the
+    // empty line
+    List<Object[]> records =
+        runParser(
+            config,
+            Arrays.asList(
+                "{\"_c0\":true,\"_c1\":10,\"_c2\":\"first\"}",
+                "{\"_c0\":false,\"_c1\":20,\"_c2\":\"second\"}",
+                "")); // Empty line at the end
+
+    assertEquals(2, records.size());
+    assertEquals(true, records.get(0)[0]);
+    assertEquals(10L, records.get(0)[1]);
+    assertEquals("first", records.get(0)[2]);
+  }
+
+  @Test
+  public void testLeadingEmptyLine() throws Exception {
+    SchemaConfig schema =
+        schema(column("_c0", BOOLEAN), column("_c1", LONG), column("_c2", STRING));
+    ConfigSource config = config().set("columns", schema);
+
+    List<Object[]> records =
+        runParser(
+            config,
+            Arrays.asList(
+                "", // Empty line at the beginning
+                "{\"_c0\":true,\"_c1\":10,\"_c2\":\"first\"}",
+                "{\"_c0\":false,\"_c1\":20,\"_c2\":\"second\"}"));
+
+    assertEquals(2, records.size());
+  }
+
+  @Test
+  public void testMiddleEmptyLine() throws Exception {
+    SchemaConfig schema =
+        schema(column("_c0", BOOLEAN), column("_c1", LONG), column("_c2", STRING));
+    ConfigSource config = config().set("columns", schema);
+
+    List<Object[]> records =
+        runParser(
+            config,
+            Arrays.asList(
+                "{\"_c0\":true,\"_c1\":10,\"_c2\":\"first\"}",
+                "", // Empty line in the middle
+                "{\"_c0\":false,\"_c1\":20,\"_c2\":\"second\"}"));
+
+    assertEquals(2, records.size());
+  }
+
+  @Test
+  public void testMultipleConsecutiveEmptyLines() throws Exception {
+    SchemaConfig schema =
+        schema(column("_c0", BOOLEAN), column("_c1", LONG), column("_c2", STRING));
+    ConfigSource config = config().set("columns", schema);
+
+    List<Object[]> records =
+        runParser(
+            config,
+            Arrays.asList(
+                "{\"_c0\":true,\"_c1\":10,\"_c2\":\"first\"}",
+                "", // Empty line
+                "", // Empty line
+                "", // Empty line
+                "{\"_c0\":false,\"_c1\":20,\"_c2\":\"second\"}"));
+
+    assertEquals(2, records.size());
+  }
+
+  @Test
+  public void testWhitespaceOnlyLines() throws Exception {
+    SchemaConfig schema =
+        schema(column("_c0", BOOLEAN), column("_c1", LONG), column("_c2", STRING));
+    ConfigSource config = config().set("columns", schema);
+
+    List<Object[]> records =
+        runParser(
+            config,
+            Arrays.asList(
+                "{\"_c0\":true,\"_c1\":10,\"_c2\":\"first\"}",
+                "   ", // Spaces only
+                "\t", // Tab only
+                "  \t  ", // Mixed whitespace
+                "{\"_c0\":false,\"_c1\":20,\"_c2\":\"second\"}"));
+
+    assertEquals(2, records.size());
+  }
+
+  @Test
+  public void testOnlyEmptyLines() throws Exception {
+    SchemaConfig schema =
+        schema(column("_c0", BOOLEAN), column("_c1", LONG), column("_c2", STRING));
+    ConfigSource config = config().set("columns", schema);
+
+    List<Object[]> records = runParser(config, Arrays.asList("", "   ", "\t", ""));
+
+    assertEquals(0, records.size());
+  }
+
+  @Test
+  public void testEmptyLinesWithStopOnInvalidRecord() throws Exception {
+    SchemaConfig schema =
+        schema(column("_c0", BOOLEAN), column("_c1", LONG), column("_c2", STRING));
+    ConfigSource config = config().set("columns", schema).set("stop_on_invalid_record", true);
+
+    // Empty lines should be skipped even when stop_on_invalid_record is true
+    List<Object[]> records =
+        runParser(
+            config,
+            Arrays.asList(
+                "{\"_c0\":true,\"_c1\":10,\"_c2\":\"first\"}",
+                "",
+                "{\"_c0\":false,\"_c1\":20,\"_c2\":\"second\"}"));
+
+    assertEquals(2, records.size());
+  }
+
   private ConfigSource config() {
     return CONFIG_MAPPER_FACTORY.newConfigSource();
   }


### PR DESCRIPTION
## 概要 

n-transfer-uiでQAしていただいた時に見つかったバグの修正です。

ファイル末尾の改行などで空やスペースだけの行がある時にエラーになってしまっていたため、
そのチェック処理とユニットテストを追加しました。


## 動作確認内容

このブランチからテスト用のタグを作り、ローカルのn-transfer-uiで問題が改善していることを確認しました。

https://github.com/primenumber-dev/embulk-parser-jsonl/blob/master/example/sample.json をGCSに配置
→Bigqueryへのデータ転送が正常に完了し、転送されたデータもsample.jsonと同じ内容が入っていること